### PR TITLE
update hard disk cartridge to use value store for persistent settings values

### DIFF
--- a/HardDisk/harddisk.cpp
+++ b/HardDisk/harddisk.cpp
@@ -298,7 +298,7 @@ void SaveConfig()
 {
 	::vcc::utils::persistent_value_section_store value_store(IniFile, gConfigurationSection);
 	
-	// TODO-CHET: The originally this used the ValidatePath function to try and change the path
+	// TODO-CHET: Originally this used the ValidatePath function to try and change the path
 	// to something relative to the main application path. This was likely used for installing
 	// from a zip file onto a USB drive (i.e. mobility). This functionality is currently deferred
 	// until the hard disk cartridge is reworked/refactored and the host interface is updated to


### PR DESCRIPTION

- Change `VHDfile0` to `std::filesystem::path`
- Change `VHDfile1` to `std::filesystem::path`
- Change `HardDiskPath` to `std::filesystem::path`
- Update `SaveConfig` to use `persistent_value_section_store` for writing persistent settings.
- Update `LoadConfig` to use `persistent_value_section_store` for reading persistent settings.
- Update `LoadConfig` to use `std::filesystem::exists` for checking if hard disk image exists for mounting.

Resolves #55 